### PR TITLE
fix: install esbuild globally in CI for SAM build compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,6 +95,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install esbuild globally
+        run: npm install -g esbuild
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -201,6 +204,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Install esbuild globally
+        run: npm install -g esbuild
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
pnpm's symlink-based node_modules structure doesn't expose the esbuild binary on the system PATH. SAM's NodejsNpmEsbuildBuilder requires esbuild on PATH since it runs `npm install --production` internally which skips devDependencies. Installing esbuild globally ensures SAM can find it during the EsbuildBundle step.

https://claude.ai/code/session_015AKp9WqGW7KysPtfvKwv5x

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
