### PR TITLE
fix: move misplaced parameters into Parameters section in SAM template

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -39,6 +39,94 @@ Parameters:
     Description: Supabase service role key
     NoEcho: true
 
+  WhatsAppPhoneNumberId:
+    Type: String
+    Description: WhatsApp Cloud API Phone Number ID
+    NoEcho: true
+    Default: ""
+
+  WhatsAppAccessToken:
+    Type: String
+    Description: WhatsApp Cloud API Access Token
+    NoEcho: true
+    Default: ""
+
+  WhatsAppWebhookVerifyToken:
+    Type: String
+    Description: WhatsApp Webhook Verification Token
+    NoEcho: true
+    Default: ""
+
+  SmilePartnerId:
+    Type: String
+    Description: Smile Identity Partner ID
+    NoEcho: true
+    Default: ""
+
+  SmileApiKey:
+    Type: String
+    Description: Smile Identity API Key
+    NoEcho: true
+    Default: ""
+
+  SmileEnvironment:
+    Type: String
+    Description: Smile Identity Environment (sandbox/production)
+    Default: sandbox
+    AllowedValues:
+      - sandbox
+      - production
+
+  EcocashMerchantId:
+    Type: String
+    Description: EcoCash Merchant ID
+    NoEcho: true
+    Default: ""
+
+  EcocashApiKey:
+    Type: String
+    Description: EcoCash API Key
+    NoEcho: true
+    Default: ""
+
+  OnemoneyMerchantId:
+    Type: String
+    Description: OneMoney Merchant ID
+    NoEcho: true
+    Default: ""
+
+  OnemoneyApiKey:
+    Type: String
+    Description: OneMoney API Key
+    NoEcho: true
+    Default: ""
+
+  TrustonicApiKey:
+    Type: String
+    Description: Trustonic API Key
+    NoEcho: true
+    Default: ""
+
+  TrustonicApiSecret:
+    Type: String
+    Description: Trustonic API Secret
+    NoEcho: true
+    Default: ""
+
+  SmsProvider:
+    Type: String
+    Description: SMS Provider (twilio/africas_talking)
+    Default: twilio
+    AllowedValues:
+      - twilio
+      - africas_talking
+
+  SmsApiKey:
+    Type: String
+    Description: SMS Provider API Key
+    NoEcho: true
+    Default: ""
+
 Resources:
   # =====================================================
   # 1. SCORING SERVICE
@@ -265,95 +353,6 @@ Resources:
         Target: es2020
         EntryPoints:
           - src/index.ts
-
-# Additional Parameters (Sensitive)
-  WhatsAppPhoneNumberId:
-    Type: String
-    Description: WhatsApp Cloud API Phone Number ID
-    NoEcho: true
-    Default: ""
-
-  WhatsAppAccessToken:
-    Type: String
-    Description: WhatsApp Cloud API Access Token
-    NoEcho: true
-    Default: ""
-
-  WhatsAppWebhookVerifyToken:
-    Type: String
-    Description: WhatsApp Webhook Verification Token
-    NoEcho: true
-    Default: ""
-
-  SmilePartnerId:
-    Type: String
-    Description: Smile Identity Partner ID
-    NoEcho: true
-    Default: ""
-
-  SmileApiKey:
-    Type: String
-    Description: Smile Identity API Key
-    NoEcho: true
-    Default: ""
-
-  SmileEnvironment:
-    Type: String
-    Description: Smile Identity Environment (sandbox/production)
-    Default: sandbox
-    AllowedValues:
-      - sandbox
-      - production
-
-  EcocashMerchantId:
-    Type: String
-    Description: EcoCash Merchant ID
-    NoEcho: true
-    Default: ""
-
-  EcocashApiKey:
-    Type: String
-    Description: EcoCash API Key
-    NoEcho: true
-    Default: ""
-
-  OnemoneyMerchantId:
-    Type: String
-    Description: OneMoney Merchant ID
-    NoEcho: true
-    Default: ""
-
-  OnemoneyApiKey:
-    Type: String
-    Description: OneMoney API Key
-    NoEcho: true
-    Default: ""
-
-  TrustonicApiKey:
-    Type: String
-    Description: Trustonic API Key
-    NoEcho: true
-    Default: ""
-
-  TrustonicApiSecret:
-    Type: String
-    Description: Trustonic API Secret
-    NoEcho: true
-    Default: ""
-
-  SmsProvider:
-    Type: String
-    Description: SMS Provider (twilio/africas_talking)
-    Default: twilio
-    AllowedValues:
-      - twilio
-      - africas_talking
-
-  SmsApiKey:
-    Type: String
-    Description: SMS Provider API Key
-    NoEcho: true
-    Default: ""
 
 Outputs:
   # API Gateway Endpoint


### PR DESCRIPTION
13 parameter definitions (WhatsApp, Smile Identity, EcoCash, OneMoney, Trustonic, SMS) were placed after the Resources section instead of inside the Parameters block. CloudFormation treated them as resources with Type: String, causing sam validate --lint to fail with E3001/E3006 errors.

https://claude.ai/code/session_019ezWnRbYMmDPxnzuStsfed

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
