### PR TITLE
fix: replace EventBridge schedule with API endpoint for lock processing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,6 +113,21 @@ jobs:
       - name: SAM Validate
         run: sam validate --lint
 
+      - name: Clean up failed stack if in ROLLBACK_COMPLETE
+        run: |
+          STACK_STATUS=$(aws cloudformation describe-stacks \
+            --stack-name lynia-finance-staging \
+            --query 'Stacks[0].StackStatus' \
+            --output text 2>/dev/null || echo "DOES_NOT_EXIST")
+          if [ "$STACK_STATUS" = "ROLLBACK_COMPLETE" ]; then
+            echo "Stack is in ROLLBACK_COMPLETE state. Deleting before redeploy..."
+            aws cloudformation delete-stack --stack-name lynia-finance-staging
+            aws cloudformation wait stack-delete-complete --stack-name lynia-finance-staging
+            echo "Stack deleted successfully."
+          else
+            echo "Stack status: $STACK_STATUS - no cleanup needed."
+          fi
+
       - name: SAM Deploy to Staging
         run: |
           sam deploy \

--- a/services/lock-service/src/index.ts
+++ b/services/lock-service/src/index.ts
@@ -1,4 +1,4 @@
-import { APIGatewayProxyEvent, APIGatewayProxyResult, ScheduledEvent } from 'aws-lambda';
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { createClient } from '@supabase/supabase-js';
 import { HandoverService, InitiateHandoverRequest } from './handover-service';
 import { LockManagementService } from './lock-management-service';
@@ -16,46 +16,41 @@ const lockService = new LockManagementService();
  * Handles device lock/unlock operations (Trustonic integration)
  */
 export const handler = async (
-  event: APIGatewayProxyEvent | ScheduledEvent
-): Promise<APIGatewayProxyResult | void> => {
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
   try {
-    // Handle scheduled event (cron job for automated lock processing)
-    if ('source' in event && event.source === 'aws.events') {
-      return await processAutomatedLocks();
-    }
+    console.log('Event:', JSON.stringify(event, null, 2));
 
-    // Handle API Gateway events
-    const apiEvent = event as APIGatewayProxyEvent;
-    console.log('Event:', JSON.stringify(apiEvent, null, 2));
-
-    const path = apiEvent.path;
-    const method = apiEvent.httpMethod;
+    const path = event.path;
+    const method = event.httpMethod;
 
     // Lock/Unlock endpoints
     if (path === '/locks/lock' && method === 'POST') {
-      return await lockDevice(apiEvent);
+      return await lockDevice(event);
     } else if (path === '/locks/unlock' && method === 'POST') {
-      return await unlockDevice(apiEvent);
+      return await unlockDevice(event);
+    } else if (path === '/locks/process-scheduled' && method === 'POST') {
+      return await processAutomatedLocksApi();
     } else if (path.startsWith('/locks/') && method === 'GET') {
-      const deviceId = apiEvent.pathParameters?.deviceId;
+      const deviceId = event.pathParameters?.deviceId;
       return await getLockStatus(deviceId!);
     }
 
     // Handover endpoints
     else if (path === '/handovers/check-readiness' && method === 'POST') {
-      return await checkHandoverReadiness(apiEvent);
+      return await checkHandoverReadiness(event);
     } else if (path === '/handovers/initiate' && method === 'POST') {
-      return await initiateHandover(apiEvent);
+      return await initiateHandover(event);
     } else if (path === '/handovers/verify-identity' && method === 'POST') {
-      return await verifyIdentity(apiEvent);
+      return await verifyIdentity(event);
     } else if (path === '/handovers/verify-deposit' && method === 'POST') {
-      return await verifyDeposit(apiEvent);
+      return await verifyDeposit(event);
     } else if (path === '/handovers/device-condition' && method === 'POST') {
-      return await recordDeviceCondition(apiEvent);
+      return await recordDeviceCondition(event);
     } else if (path === '/handovers/complete' && method === 'POST') {
-      return await completeHandover(apiEvent);
+      return await completeHandover(event);
     } else if (path.match(/\/handovers\/[^/]+$/) && method === 'GET') {
-      const handoverId = apiEvent.pathParameters?.handoverId;
+      const handoverId = event.pathParameters?.handoverId;
       return await getHandoverStatus(handoverId!);
     }
 
@@ -206,16 +201,29 @@ async function getLockStatus(deviceId: string): Promise<APIGatewayProxyResult> {
   }
 }
 
-async function processAutomatedLocks(): Promise<void> {
+async function processAutomatedLocksApi(): Promise<APIGatewayProxyResult> {
   try {
     console.log('Processing automated device locks...');
 
     const result = await lockService.processAutomatedLocks();
 
-    console.log(`Automated lock processing complete:`, result);
+    console.log('Automated lock processing complete:', result);
 
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ success: true, result }),
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
+    };
   } catch (error) {
     console.error('Error during automated lock processing:', error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        error: 'Failed to process automated locks',
+        message: error instanceof Error ? error.message : 'Unknown error'
+      }),
+      headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' }
+    };
   }
 }
 

--- a/template.yaml
+++ b/template.yaml
@@ -308,11 +308,13 @@ Resources:
           Properties:
             Path: /locks/{deviceId}
             Method: GET
-        ScheduledLockProcessing:
-          Type: Schedule
+        # Trigger lock processing via API instead of EventBridge schedule
+        # (EventBridge requires events:* IAM permissions on the deploy user)
+        ProcessScheduledLocks:
+          Type: Api
           Properties:
-            Schedule: cron(0 8 * * ? *)  # Daily at 8 AM UTC
-            Description: Process automated device locks
+            Path: /locks/process-scheduled
+            Method: POST
     Metadata:
       BuildMethod: esbuild
       BuildProperties:


### PR DESCRIPTION
The github-actions-deploy IAM user lacks events:DescribeRule permission, causing the ScheduledLockProcessing EventBridge rule to fail during CloudFormation stack creation. Replace the Schedule event with an API endpoint (POST /locks/process-scheduled) that can be triggered by an external scheduler or cron service.

Also adds a pre-deploy step to clean up stacks stuck in ROLLBACK_COMPLETE state from the previous failed deployment.

https://claude.ai/code/session_017pUWX5ZEezPXabf4FZ9F2q

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
