### PR TITLE
fix: consolidate test steps to ensure coverage report is generated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,22 +39,20 @@ jobs:
         run: pnpm run lint
         continue-on-error: true
 
-      - name: Run unit tests
-        run: pnpm run test
+      - name: Run tests with coverage
+        run: pnpm run test:coverage
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_TEST_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_TEST_KEY }}
 
-      - name: Generate coverage report
-        run: pnpm run test -- --coverage
-        continue-on-error: true
-
       - name: Upload coverage to Codecov
+        if: always()
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage/lcov.info
           flags: unittests
           name: codecov-umbrella
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
       - name: Comment coverage on PR


### PR DESCRIPTION
The Codecov upload was failing because coverage/lcov.info was not found. The workflow ran tests twice (once without coverage, once with) and the coverage step had continue-on-error: true, silently failing without generating the report. This consolidates into a single test:coverage step, adds if: always() so the upload runs even on test failure, and adds the CODECOV_TOKEN for authenticated uploads.

https://claude.ai/code/session_01RC8R49p5RYYy83mtSfHUJS

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
