### PR TITLE
fix: suppress cfn-lint W1030 false positive for conditional VPC params

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -4,6 +4,17 @@ Description: >
   Lynia Finance - Serverless Microservices
   6 Lambda functions for Phase 2: Scoring, WhatsApp, KYC, Payment, Lock, Notification
 
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        # VPC parameters (SecurityGroupId, SubnetIds) are typed as String with
+        # empty defaults because VPC is optional (controlled by the UseVPC
+        # condition).  cfn-lint cannot resolve the !If condition at lint time
+        # so it incorrectly flags every Ref to these parameters as not matching
+        # the sg-*/subnet-* patterns.
+        - W1030
+
 # Global configuration for all functions
 Globals:
   Function:


### PR DESCRIPTION
VPC parameters (LambdaSecurityGroupId, PrivateSubnet1Id, PrivateSubnet2Id) are typed as String with empty defaults because VPC is optional. cfn-lint cannot resolve the !If UseVPC condition at lint time and incorrectly flags every Ref as not matching the sg-*/subnet-* patterns (27 warnings).

https://claude.ai/code/session_01TE3keT66niCFR8J1zgo6VN

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
