### PR TITLE
fix: add AllowedPattern to LambdaSecurityGroupId to fix cfn-lint W1030

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -160,7 +160,8 @@ Parameters:
 
   LambdaSecurityGroupId:
     Type: String
-    Default: ""
+    Default: "sg-00000000"
+    AllowedPattern: "^sg-[a-fA-F0-9]{8,17}$"
     Description: Lambda Security Group ID from VPC stack
 
 Conditions:


### PR DESCRIPTION
The LambdaSecurityGroupId parameter was Type: String with Default: "", which caused cfn-lint W1030 to flag 27 violations because the Ref didn't resolve to a valid AWS::EC2::SecurityGroup.Id pattern.

Added AllowedPattern constraining values to valid SG ID format and changed the default to a placeholder sg-00000000. The default is only used when VpcEnabled=false, where the UseVPC condition ensures VpcConfig resolves to AWS::NoValue (so the SG ID is never evaluated).

https://claude.ai/code/session_01REcJiNVuyczNcGwiVNHwkw

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
