### PR TITLE
fix: remove ReservedConcurrentExecutions to fix SAM deploy failure

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -243,7 +243,6 @@ Resources:
       CodeUri: services/whatsapp-service/
       Handler: dist/index.handler
       Description: WhatsApp messaging and webhook service
-      ReservedConcurrentExecutions: 100
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -371,7 +370,6 @@ Resources:
       Description: Payment processing service (EcoCash, OneMoney integration)
       MemorySize: 1024
       Timeout: 60
-      ReservedConcurrentExecutions: 50
       AutoPublishAlias: live
       Policies:
         - Version: "2012-10-17"


### PR DESCRIPTION
The AWS account's Lambda concurrency quota is too low to support 150 reserved concurrent executions (100 WhatsApp + 50 Payment) while maintaining the required minimum of 10 unreserved. Removing ReservedConcurrentExecutions from both functions allows deployment to succeed. Reserved concurrency can be re-added after requesting an AWS quota increase.

https://claude.ai/code/session_019c8Pow3SUGjnAgjyBTkgWc

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
